### PR TITLE
Issue 309 - Back button on login and signup page

### DIFF
--- a/front/components/authPage/AuthPage.vue
+++ b/front/components/authPage/AuthPage.vue
@@ -13,6 +13,9 @@
       />
     </v-col>
     <v-col cols="12" md="4" class="auth-page__content">
+      <v-icon class="auth-page__go-back-icon hidden-md-and-up" @click="goBack()"
+        >fas fa-times</v-icon>
+
       <div class="auth-page__content__header">
         <div class="auth-page__content__header__lamp-image-container">
           <div
@@ -48,6 +51,8 @@
       </div>
     </v-col>
     <v-col cols="0" md="4" class="auth-page__right">
+      <v-icon class="auth-page__go-back-icon" @click="goBack()"
+        >fas fa-times</v-icon>
       <img
         src="~/assets/images/smallTree.png"
         class="auth-page__right__tree  hidden-sm-and-down"
@@ -71,6 +76,13 @@ export default {
       default: false
     }
   },
+
+  methods: {
+    goBack() {
+      window.history.back();
+    }
+  },
+
   computed: {},
   mounted() {
     this.$el.removeAttribute('hidden')
@@ -84,6 +96,13 @@ export default {
   background-size: 100% auto;
   background-position: 50% 120%;
   background-repeat: no-repeat;
+
+  &__go-back-icon {
+    position: absolute;
+    right: 0.5rem;
+    top: 0.5rem;
+    color: $color-muted-grey;
+  }
 
   &__content {
     position: relative;


### PR DESCRIPTION
#309 

I could not figure out how to get the &times button to show in the right column on mobile due to it becoming hidden. As a result, I ended up having to use two v-icons and hide one on the larger screens.

This doesn't feel right, so any suggestions on how to fix this would be appreciated. 