### PR TITLE
Issue 330 - Made 'copy link' more muted and removed redundant scss var

### DIFF
--- a/front/assets/style/common.scss
+++ b/front/assets/style/common.scss
@@ -18,7 +18,7 @@
 
 .muted,
 .muted .v-icon {
-  color: $color-muted-grey;
+  color: $color-muted-grey !important;
 }
 
 form .v-input__prepend-inner {

--- a/front/assets/style/variables.scss
+++ b/front/assets/style/variables.scss
@@ -1,6 +1,5 @@
 $primary-color: #5B41BB;
 $secondary-color: #ffc61e;
-$accent-color: rgba(192, 183, 197);
 $secondary-gradient: linear-gradient(to left, #ffb92d, #ffdf01);
 $color-muted-grey: #c0b7c5;
 $color-insanely-crazy-light-greyish-purple: #f3f0f4;

--- a/front/components/dialogs/commentWithoutLogin.vue
+++ b/front/components/dialogs/commentWithoutLogin.vue
@@ -178,7 +178,7 @@ export default {
     .subTitle {
       padding: 10px 0px;
       font-size: 16px;
-      color: $accent-color;
+      color: $color-muted-grey;
     }
     .emailInput {
       padding-top: 20px;


### PR DESCRIPTION
1. Copy link text already had a `muted` class applied to it, but it was being overridden by v-application a's color. So I added an !important to the .muted class in common.scss

2. There was an rgba color in variables.scss called `$accent-color` . It was the same color as `$color-muted-grey` but it may have been overlooked due to `$accent-color` being an RGBA value and the rest being hex values. Since I couldn't see a good reason to keep accent-color, I removed it and replaced all occurrences of it in the code with `$color-muted-grey`