### PR TITLE
Issue 461: Fix swipe offset

### DIFF
--- a/front/components/ideaDetail/Swiper.vue
+++ b/front/components/ideaDetail/Swiper.vue
@@ -117,10 +117,16 @@ export default {
     enableScroll() {
       document.querySelector('body').style.overflow = ''
     },
+    startSwipe() {
+      this.$emit('swipe-start')
+    },
+    endSwipe() {
+      this.$emit('swipe-end')
+    },
     fingerDown(event) {
       this.disableScroll()
       this.tapping = true
-      this.$emit('swipe-start')
+      this.startSwipe()
       const { x, y } = this.getPos(event)
       this.xStart = x
       this.yStart = y
@@ -131,7 +137,7 @@ export default {
     fingerUp(event) {
       this.enableScroll()
       this.tapping = false
-      this.$emit('swipe-end')
+      this.endSwipe()
       if (this.x) {
         if (this.x > this.minSwipeDistanceBeforeAction) {
           this.$emit('swipe-right')

--- a/front/components/ideaDetail/Swiper.vue
+++ b/front/components/ideaDetail/Swiper.vue
@@ -103,7 +103,7 @@ export default {
       }
 
       event.preventDefault()
-      this.x = x - this.xCenter - this.xDistanceToCenter
+      this.x = x - this.xStart
       this.rotation = this.getRotation(x)
     },
     getRotation(x) {

--- a/front/components/ideaDetail/Swiper.vue
+++ b/front/components/ideaDetail/Swiper.vue
@@ -133,9 +133,9 @@ export default {
       this.tapping = false
       this.$emit('swipe-end')
       if (this.x) {
-        if (this.x > this.xStart + this.minSwipeDistanceBeforeAction) {
+        if (this.x > this.minSwipeDistanceBeforeAction) {
           this.$emit('swipe-right')
-        } else if (this.x < this.xStart - this.minSwipeDistanceBeforeAction) {
+        } else if (this.x < -this.minSwipeDistanceBeforeAction) {
           this.$emit('swipe-left')
         }
       }

--- a/front/components/ideaDetail/Swiper.vue
+++ b/front/components/ideaDetail/Swiper.vue
@@ -21,6 +21,7 @@ export default {
       tapping: false,
       swipeSensitivity: 50,
       minSwipeDistanceBeforeAction: 75,
+      swipeInProgress: false,
       xStart: 0,
       yStart: 0,
       xVal: 0,

--- a/front/components/ideaDetail/Swiper.vue
+++ b/front/components/ideaDetail/Swiper.vue
@@ -98,8 +98,16 @@ export default {
     },
     setPos(event) {
       const { x } = this.getPos(event)
-      if (Math.abs(this.xStart - x) < this.swipeSensitivity) {
-        return
+      if (this.swipeInProgress === false) {
+        // We haven't lifted the card yet
+        if (Math.abs(this.xStart - x) < this.swipeSensitivity) {
+          // AND the card hasn't traveled very car from it's original position
+          // so do nothing
+          return
+        } else {
+          // the card HAS traveled far enough now, so officially start the swipe
+          this.startSwipe()
+        }
       }
 
       event.preventDefault()
@@ -119,14 +127,15 @@ export default {
     },
     startSwipe() {
       this.$emit('swipe-start')
+      this.swipeInProgress = true
     },
     endSwipe() {
       this.$emit('swipe-end')
+      this.swipeInProgress = false
     },
     fingerDown(event) {
       this.disableScroll()
       this.tapping = true
-      this.startSwipe()
       const { x, y } = this.getPos(event)
       this.xStart = x
       this.yStart = y

--- a/front/pages/i/_shortId/_slug.vue
+++ b/front/pages/i/_shortId/_slug.vue
@@ -9,7 +9,11 @@
       @left-arrow-clicked="previousIdea"
       @right-arrow-clicked="nextIdea"
     >
-      <v-row :style="rotationStyle" align="stretch" class="elevation-2 ma-1 card">
+      <v-row
+        :style="rotationStyle"
+        align="stretch"
+        class="elevation-2 ma-1 card"
+      >
         <v-col cols="12" md="8" class="idea-part">
           <div>
             <v-row class="idea-part__header" no-gutters>

--- a/front/pages/i/_shortId/_slug.vue
+++ b/front/pages/i/_shortId/_slug.vue
@@ -9,7 +9,7 @@
       @left-arrow-clicked="previousIdea"
       @right-arrow-clicked="nextIdea"
     >
-      <v-row :style="rotationStyle" align="stretch">
+      <v-row :style="rotationStyle" align="stretch" class="elevation-2 ma-1 card">
         <v-col cols="12" md="8" class="idea-part">
           <div>
             <v-row class="idea-part__header" no-gutters>
@@ -547,6 +547,13 @@ export default {
   font-size: 24px;
 }
 
+.card {
+  border: 1px solid $color-insanely-crazy-light-greyish-purple;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  /* .rounded doesn't work because i'm applying this to a .row (which i shouldn't) */
+}
 .idea-part {
   @media (min-width: $screen-md-min) {
     min-height: calc(100vh - 88px);


### PR DESCRIPTION
Resolves https://github.com/ezl/dailyidea.com/issues/461

The starting X position was being used twice, which was causing an offset.

To resolve, 2 commits:

1. simpler assignment (no functional change)
2. remove the double comparison (fixes the offset)

--

The following 2 commits are beyond the scope of the original ticket, but I balled it in because it's in the same section of code.

I realized that the drag behavior through the original pickup point is a bit choppy because the `setPos` method is ALWAYS comparing for `startX - x` vs `swipeSensitivity`. I think the intended behavior is to only do this on the FIRST drag.
