### PR TITLE
Issue 480 detect mobile

### DIFF
--- a/front/components/ideaDetail/MenuPanel.vue
+++ b/front/components/ideaDetail/MenuPanel.vue
@@ -192,7 +192,7 @@ export default {
     },
 
     showShareIdeaDialog() {
-      if (navigator.share) {
+      if (this.isMobile) {
         navigator.share({
           title: this.idea.title,
           url: window.location.href

--- a/front/plugins/mixins.js
+++ b/front/plugins/mixins.js
@@ -1,6 +1,11 @@
 import Vue from 'vue'
 
 Vue.mixin({
+  computed: {
+    isMobile() {
+      return !!navigator.share
+    }
+  },
   methods: {
     $scrollToFirstError() {
       const field = this.$validator.errors.items[0].field

--- a/front/plugins/mixins.js
+++ b/front/plugins/mixins.js
@@ -3,7 +3,7 @@ import Vue from 'vue'
 Vue.mixin({
   computed: {
     isMobile() {
-      return !!navigator.share
+      return !!navigator.share || this.$vuetify.breakpoint.smAndDown
     }
   },
   methods: {


### PR DESCRIPTION
Adds a computed property to `mixins.js` in `plugins` that uses `navigator.share` to determine whether the user is on a mobile device or not.

Doing this makes a property, `this.isMobile` available in all other components.

I am a bit unsure about my implementation though, specifically about putting it in `mixins.js`. I am concerned that it isn't immediately obvious that we have this `isMobile` property now. @aldarund any suggestions on how to make this cleaner would be very helpful.